### PR TITLE
Focus row on creating new scenario

### DIFF
--- a/web-ui/src/resources/elements/test-list.ts
+++ b/web-ui/src/resources/elements/test-list.ts
@@ -36,6 +36,7 @@ export class TestList {
         this.subscriptions.push(this.eventAggregator.subscribe(AppEventPublisher.onNewScenario, response => {
             this.entries.splice(this.entries.length, 0, response);
             this.listChanged();
+            this.focusRow(this.entries.length - 1);
         }));
 
         this.subscriptions.push(this.eventAggregator.subscribe(AppEventPublisher.appMainColumnsResized, response => {
@@ -77,6 +78,15 @@ export class TestList {
 
     detached() {
 
+    }
+
+    focusRow(rowIndex: number) {
+        if (this.api.getInfiniteRowCount() < rowIndex) {
+            this.api.setInfiniteRowCount(rowIndex, false);
+        }
+        this.api.ensureIndexVisible(rowIndex);
+        this.api.selectIndex(rowIndex, false, false);
+        this.selectionChanged();
     }
 
     listChanged(splices?: Array<ICollectionObserverSplice<any>>) {


### PR DESCRIPTION
With the "get/setInfinitiveRowCount" I'm making sure that the row is rendered by the DOM as it has some lazy loading if I understood that correctly. Probably you now that anyway ^^
The ensureIndexVisible-function scrolls to the position.
Then I select the index using the gridApi. It's `selectIndex(index: any, tryMulti: any, suppressEvents: any): void`
As my second parameter is "false" the line is the only selected row. The third parameter says that no events are suppressed, so the "Edit Scenario" is updated as well and then I call the selectionChanged-function which sets this.currEntry to the correct one.

Feel free to suggest improvements if I'm missing something ;)

See here the change in action:
https://1drv.ms/u/s!ApL7yYkbo0jQg5laXcFCIJS_NC_m3Q?e=93PyYu