### PR TITLE
Allow only the five comment tags

### DIFF
--- a/services/ATDD.TestScriptor.BackendServices/Hubs/ATDDHub.cs
+++ b/services/ATDD.TestScriptor.BackendServices/Hubs/ATDDHub.cs
@@ -32,9 +32,10 @@ namespace ATDD.TestScriptor.BackendServices.Hubs
             await Clients.All.GetObjects(result);
         }
 
-        public async Task SaveChanges(IEnumerable<Message> msg)
+        public async Task SaveChanges(MessageUpdate msg)
         {
-            await Clients.All.SaveChangesResponse(msg);
+            objectService.SaveChanges(msg);
+            await Clients.All.SaveChangesResponse(true);
         }
 
     }

--- a/services/ATDD.TestScriptor.BackendServices/Hubs/IATDDHub.cs
+++ b/services/ATDD.TestScriptor.BackendServices/Hubs/IATDDHub.cs
@@ -1,5 +1,6 @@
 ﻿using ATDD.TestScriptor.BackendServices.Models;
 using ATDD.TestScriptor.Library;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -9,6 +10,6 @@ namespace ATDD.TestScriptor.BackendServices.Hubs
     {
         Task GetProjects(IEnumerable<ALProject> msg);
         Task GetObjects(IEnumerable<Message> msg);
-        Task SaveChangesResponse(IEnumerable<Message> msg);
+        Task SaveChangesResponse(bool response);
     }
 }

--- a/services/ATDD.TestScriptor.BackendServices/Models/Message.cs
+++ b/services/ATDD.TestScriptor.BackendServices/Models/Message.cs
@@ -43,4 +43,23 @@ namespace ATDD.TestScriptor.BackendServices.Models
         Modified,
         Deleted        
     }
+    public class MessageUpdate
+    {
+        public string Scenario { get; set; }
+        public TypeChanged Type { get; set; }
+        public MessageState State { get; set; }
+        public string OldValue { get; set; }
+        public string NewValue { get; set; }
+        public string FsPath { get; set; }
+    }
+    public enum TypeChanged
+    {
+        Feature,
+        ScenarioId,
+        ScenarioName,
+        Given,
+        When,
+        Then
+    }
 }
+

--- a/services/ATDD.TestScriptor.BackendServices/Services/ALObjectService.cs
+++ b/services/ATDD.TestScriptor.BackendServices/Services/ALObjectService.cs
@@ -1,8 +1,18 @@
-﻿using ATDD.TestScriptor.BackendServices.Models;
+﻿using ALObjectParser.Library;
+using ATDD.TestScriptor.BackendServices.Models;
 using ATDD.TestScriptor.Library;
+using Microsoft.Extensions.ObjectPool;
+using Microsoft.VisualBasic;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices.ComTypes;
+using System.Security.Cryptography;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace ATDD.TestScriptor.BackendServices.Services
@@ -10,6 +20,7 @@ namespace ATDD.TestScriptor.BackendServices.Services
     public interface IALObjectService
     {
         Task<List<Message>> GetTests(IEnumerable<string> paths);
+        void SaveChanges(MessageUpdate msg);
     }
 
     public class ALObjectService : IALObjectService
@@ -90,6 +101,75 @@ namespace ATDD.TestScriptor.BackendServices.Services
                 .ToList();
 
             return result;
+        }
+
+        public void SaveChanges(MessageUpdate msg)
+        {
+            //IEnumerable<Message> dirtyMsgs = msg.Where(m => m.IsDirty);
+            //foreach (Message dirtyMsg in dirtyMsgs)
+            //{
+            //    List<string> fileContent = File.ReadAllLines(dirtyMsg.FsPath).ToList();
+
+            //    int scenarioLine = 0;
+            //    for (int i = 0; i < fileContent.Count; i++)
+            //    {
+            //        if (Regex.IsMatch(fileContent[i], @"\s+//\s*\[Scenario.*\]\s*" + dirtyMsg.Scenario, RegexOptions.IgnoreCase))
+            //        {
+            //            scenarioLine = i;
+            //            break;
+            //        }
+            //    }
+            //    if (scenarioLine == 0)
+            //        return;
+            //    int whenLine = 0;
+
+            //    for (int i = scenarioLine; i < fileContent.Count; i++)
+            //    {
+            //        if (Regex.IsMatch(fileContent[i], @"\s+//\s*\[When\].*", RegexOptions.IgnoreCase))
+            //        {
+            //            whenLine = i;
+            //            break;
+            //        }
+            //    }
+            //    if (whenLine == 0)
+            //        return;
+
+
+            //    bool madeChanges = false;
+            //    for (int a = dirtyMsg.Details.given.ToList().Count - 1; a >= 0; a--)
+            //    {
+            //        string given = dirtyMsg.Details.given.ToList()[a];
+            //        bool found = false;
+            //        for (int i = scenarioLine; i < fileContent.Count; i++)
+            //        {
+            //            if (Regex.IsMatch(fileContent[i], @"\s+//\s*\[Given\]\s*" + given, RegexOptions.IgnoreCase))
+            //            {
+            //                found = true;
+            //            }
+            //        }
+            //        if (!found)
+            //        {
+            //            var givenTitleCase = new Regex(@"[^\w]").Replace(given.ToLower(), " ");
+            //            TextInfo info = CultureInfo.CurrentCulture.TextInfo;
+            //            givenTitleCase = info.ToTitleCase(givenTitleCase).Replace(" ", string.Empty);
+            //            fileContent.Insert(whenLine, "");
+            //            fileContent.Insert(whenLine, "\t\tCreate" + givenTitleCase + "();");
+            //            fileContent.Insert(whenLine, "\t\t// [GIVEN] " + given);
+            //            madeChanges = true;
+            //        }
+            //    }
+            //    if (madeChanges)
+            //    {
+            //        File.WriteAllLines(dirtyMsg.FsPath, fileContent, System.Text.Encoding.Unicode);
+            //    }
+
+            //    var newMsgs = msg.Where(m => m.State == MessageState.New && m.FsPath == pathToDirtyFile);
+            //    foreach (Message newMsg in newMsgs)
+            //    {
+
+            //        newMsg.Details.given
+            //    }
+            //}
         }
     }
 }

--- a/services/ATDD.TestScriptor.Library/Parsers/ALTestCodeunitReader.cs
+++ b/services/ATDD.TestScriptor.Library/Parsers/ALTestCodeunitReader.cs
@@ -52,12 +52,12 @@ namespace ATDD.TestScriptor.Library
                 return;
 
             var testMethods = TestTarget.Methods.Where(w => w.TestMethod == true).ToList();
-            var pattern = @"\[(\w+)(.*?)\]\s+(.*)";
+            var pattern = @"\[(FEATURE|SCENARIO|GIVEN|WHEN|THEN)(.*?)\]\s+(.*)";
             var features = new List<ITestFeature>();
 
             foreach (var method in testMethods)
             {
-                var matches = Regex.Matches(method.Content, pattern);
+                var matches = Regex.Matches(method.Content, pattern, RegexOptions.IgnoreCase);
                 if (matches.Count > 0)
                 {
                     var matchList = matches.ToList();
@@ -89,7 +89,7 @@ namespace ATDD.TestScriptor.Library
                                 break;
                             case ScenarioElementType.SCENARIO:
                                 scenario = new TestScenario();
-                                scenario.ID = int.Parse(elem.Id);
+                                // scenario.ID = int.Parse(elem.Id);
                                 scenario.Name = elem.Name;
                                 scenario.MethodName = method.Name;
                                 scenario.Feature = feature;

--- a/services/ATDD.TestScriptor.Library/Parsers/ALTestCodeunitReader.cs
+++ b/services/ATDD.TestScriptor.Library/Parsers/ALTestCodeunitReader.cs
@@ -91,7 +91,7 @@ namespace ATDD.TestScriptor.Library
                                 break;
                             case ScenarioElementType.SCENARIO:
                                 scenario = new TestScenario();
-                                // scenario.ID = int.Parse(elem.Id);
+                                scenario.ID = int.Parse(elem.Id);
                                 scenario.Name = elem.Name;
                                 scenario.MethodName = method.Name;
                                 scenario.Feature = feature;

--- a/services/ATDD.TestScriptor.Library/Parsers/ALTestCodeunitReader.cs
+++ b/services/ATDD.TestScriptor.Library/Parsers/ALTestCodeunitReader.cs
@@ -52,7 +52,9 @@ namespace ATDD.TestScriptor.Library
                 return;
 
             var testMethods = TestTarget.Methods.Where(w => w.TestMethod == true).ToList();
-            var pattern = @"\[(FEATURE|SCENARIO|GIVEN|WHEN|THEN)(.*?)\]\s+(.*)";
+            var enumNames = Enum.GetNames(typeof(ScenarioElementType));
+            var enumNamesJoined = String.Join('|', enumNames);
+            var pattern = @"\[(" + enumNamesJoined + @")(.*?)\]\s+(.*)";
             var features = new List<ITestFeature>();
 
             foreach (var method in testMethods)


### PR DESCRIPTION
Currently the Object Parser breaks if there's a comment which is not in the enum. With this change only the comment tags are used which are parsable.

Furthermore the id isn't necessary anymore.