### PR TITLE
#95 rename button

### DIFF
--- a/web-ui/src/resources/elements/toolbar.html
+++ b/web-ui/src/resources/elements/toolbar.html
@@ -40,11 +40,11 @@
                         <i class="fas fa-file-excel"></i> <span class="d-none d-lg-inline">Export</span></button>
                 </li>                
                 <li>
-                    <div class="btn-group-toggle my-2 my-sm-0" data-toggle="buttons" title="No Confirmation">
+                    <div class="btn-group-toggle my-2 my-sm-0" data-toggle="buttons" title="Disable Confirmations">
                         <label class="btn ${(noConfirmations ? 'btn-outline-success' : 'btn-outline-secondary')}">
                             <span show.bind="noConfirmations"><i class="fas fa-check-square"></i></span>
                             <span show.bind="!noConfirmations"><i class="far fa-square"></i></span>
-                            <span class="d-none d-lg-inline">No Confirmation</span>
+                            <span class="d-none d-lg-inline">Disable Confirmations</span>
                             <input type="checkbox" value.bind="noConfirmations" checked.bind="noConfirmations">
                         </label>
                     </div>


### PR DESCRIPTION
As Luc mentioned in https://github.com/fluxxus-nl/ATDD.TestScriptor.VSCodeExtension/issues/95#issuecomment-1483880544 renamed the button to "Disable Confirmations":

![image](https://github.com/fluxxus-nl/ATDD.TestScriptor.VSCodeExtension/assets/25108568/6a73c79d-8ee4-41b8-b75f-c6190668a5cf)

Attempts to resolve #95 